### PR TITLE
add coverall status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # libs-dogstatsd
 
+[![Coverage Status](https://coveralls.io/repos/github/makinoy/libs-dogstatsd/badge.svg)](https://coveralls.io/github/makinoy/libs-dogstatsd)  
+
 A wrapper library of `node-dogstatsd`
 
 ```


### PR DESCRIPTION
@makinoy 

Add coverall status badge at README.

![ss](https://cloud.githubusercontent.com/assets/2867833/21213617/29e27b3a-c2d9-11e6-8afc-8cbf3ecf1fe7.png)
