### PR TITLE
Do not send 'increment' metrics by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = (config) => {
   const host = config.HOST || process.env.DOGSTATSD_HOST_IP || 'localhost';
   const port = config.PORT || process.env.DOGSTATSD_PORT || 8125;
   const cacheDns = config.cacheDns || process.env.DOGSTATSD_CACHE_DNS || true;
+  const tickDefaultOptions = config.tickDefaultOptions || { distribution:false, increment:true, timing:true };
 
   var socket = null;
   if (!mock) {
@@ -57,12 +58,15 @@ module.exports = (config) => {
         return Date.now() - startTime
       },
 
-      tick: function(stat, num, _sampleRate, _tags, options) {
+      tick: function(stat, num, _sampleRate, _tags, distribution=false, options) {
         const count = num || 1;
         const sampleRate = _sampleRate || 1;
         const tags = _tags || null;
-        const defaultOptions = { distribution:false, increment:true, timing:true };
-        const opts = { ...defaultOptions, ...options };
+        
+        if (distribution){
+          tickDefaultOptions.distribution = true
+        }
+        const opts = { ...tickDefaultOptions, ...options };
 
         if (isNaN(count)) {
           logger.error('tick second arg must be number.');

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = (config) => {
         const count = num || 1;
         const sampleRate = _sampleRate || 1;
         const tags = _tags || null;
-        const defaultOptions = { distribution:false, increment:false, timing:true };
+        const defaultOptions = { distribution:false, increment:true, timing:true };
         const opts = { ...defaultOptions, ...options };
 
         if (isNaN(count)) {

--- a/index.js
+++ b/index.js
@@ -57,10 +57,13 @@ module.exports = (config) => {
         return Date.now() - startTime
       },
 
-      tick: function(stat, num, _sampleRate, _tags, distribution=false, increment=false) {
+      tick: function(stat, num, _sampleRate, _tags, options) {
         const count = num || 1;
         const sampleRate = _sampleRate || 1;
         const tags = _tags || null;
+        const defaultOptions = { distribution:false, increment:false, timing:true };
+        const opts = { ...defaultOptions, ...options };
+
         if (isNaN(count)) {
           logger.error('tick second arg must be number.');
           return;
@@ -74,12 +77,15 @@ module.exports = (config) => {
           return;
         }
 
-        if (increment) {
+        if (opts.increment) {
           client.increment(stat + '.count', count, sampleRate, tags);
         }
 
-        client.timing(stat + '.time', this.get_elapsed(), sampleRate, tags);
-        if (distribution) {
+        if (opts.timing) {
+          client.timing(stat + '.time', this.get_elapsed(), sampleRate, tags);
+        }
+
+        if (opts.distribution) {
           client.distribution(stat + '.dist', this.get_elapsed(), sampleRate, tags);
         }
       },

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = (config) => {
         return Date.now() - startTime
       },
 
-      tick: function(stat, num, _sampleRate, _tags, distribution=false) {
+      tick: function(stat, num, _sampleRate, _tags, distribution=false, increment=false) {
         const count = num || 1;
         const sampleRate = _sampleRate || 1;
         const tags = _tags || null;
@@ -74,7 +74,10 @@ module.exports = (config) => {
           return;
         }
 
-        client.increment(stat + '.count', count, sampleRate, tags);
+        if (increment) {
+          client.increment(stat + '.count', count, sampleRate, tags);
+        }
+
         client.timing(stat + '.time', this.get_elapsed(), sampleRate, tags);
         if (distribution) {
           client.distribution(stat + '.dist', this.get_elapsed(), sampleRate, tags);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "libs-dogstatsd",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libs-dogstatsd",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
By default, `tick` sends `increment` and `timing` metrics.
It increases the number of custom metrics, so developer can specify whether or not to send these metrics with the option.
